### PR TITLE
Align example with the rest

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
         Add a single <em>synchronous</em> script on top of your head:
       </p>
       <pre><code>${`<script
-  imports="one,or-more,@esm/module"
+  data-imports="one,or-more,@esm/module"
   src="https://esm.run/data-imports"
 ><\x2fscript>`}</code></pre>
       <p>and enjoy the simplicity of a tools free development experience, ... or better, a delegated one 🥳</p>


### PR DESCRIPTION
This fixes the example to also use `data-imports` attribute as the rest of the page suggests.